### PR TITLE
feat: auto-close panel on AI session exit and fix markdown inline code

### DIFF
--- a/src/adapters/inbound/controllers/AIDetectionController.ts
+++ b/src/adapters/inbound/controllers/AIDetectionController.ts
@@ -1,31 +1,39 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { AISession, AIType } from '../../../domain/entities/AISession';
-import { ISnapshotRepository } from '../../../application/ports/outbound/ISnapshotRepository';
-import { ICaptureSnapshotsUseCase } from '../../../application/ports/inbound/ICaptureSnapshotsUseCase';
-import { IPanelStateManager } from '../../../application/services/IPanelStateManager';
+import { DiffService } from '../../../domain/services/DiffService';
+import { SessionContext } from '../../../application/ports/outbound/SessionContext';
+import { IFileSystemPort } from '../../../application/ports/outbound/IFileSystemPort';
 import { IGitPort } from '../../../application/ports/outbound/IGitPort';
 import { IFileGlobber } from '../../../application/ports/outbound/IFileGlobber';
+import { ICommentRepository } from '../../../application/ports/outbound/ICommentRepository';
+import { ISymbolPort } from '../../../application/ports/outbound/ISymbolPort';
 import { FileInfo } from '../../../application/ports/outbound/PanelState';
+import { IPanelStateManager } from '../../../application/services/IPanelStateManager';
+import { PanelStateManager } from '../../../application/services/PanelStateManager';
+import { CaptureSnapshotsUseCase } from '../../../application/useCases/CaptureSnapshotsUseCase';
+import { GenerateDiffUseCase } from '../../../application/useCases/GenerateDiffUseCase';
+import { AddCommentUseCase } from '../../../application/useCases/AddCommentUseCase';
+import { SubmitCommentsUseCase } from '../../../application/useCases/SubmitCommentsUseCase';
+import { InMemorySnapshotRepository } from '../../../infrastructure/repositories/InMemorySnapshotRepository';
 import { VscodeTerminalGateway } from '../../outbound/gateways/VscodeTerminalGateway';
 import { SidecarPanelAdapter } from '../ui/SidecarPanelAdapter';
 
 export class AIDetectionController {
-    private activeAISessions = new Map<string, AISession>();
-    private panelStateManager: IPanelStateManager | undefined;
+    /** 터미널별 독립 세션 컨텍스트 */
+    private sessions = new Map<string, SessionContext>();
 
     constructor(
-        private readonly captureSnapshotsUseCase: ICaptureSnapshotsUseCase,
-        private readonly snapshotRepository: ISnapshotRepository,
+        private readonly fileSystemGateway: IFileSystemPort,
+        private readonly gitPort: IGitPort,
+        private readonly fileGlobber: IFileGlobber,
         private readonly terminalGateway: VscodeTerminalGateway,
         private readonly getExtensionContext: () => vscode.ExtensionContext,
-        private readonly gitPort: IGitPort,
-        private readonly fileGlobber: IFileGlobber
+        private readonly commentRepository: ICommentRepository,
+        private readonly submitCommentsUseCase: SubmitCommentsUseCase,
+        private readonly diffService: DiffService,
+        private readonly symbolPort: ISymbolPort
     ) {}
-
-    setPanelStateManager(panelStateManager: IPanelStateManager): void {
-        this.panelStateManager = panelStateManager;
-    }
 
     activate(context: vscode.ExtensionContext): void {
         context.subscriptions.push(
@@ -56,7 +64,7 @@ export class AIDetectionController {
             const terminalId = this.getTerminalId(terminal);
 
             // Skip if already have an active session for this terminal
-            if (this.activeAISessions.has(terminalId)) {
+            if (this.sessions.has(terminalId)) {
                 return;
             }
 
@@ -92,62 +100,189 @@ export class AIDetectionController {
         );
     }
 
+    private isAICommand(commandLine: string): boolean {
+        return this.isClaudeCommand(commandLine) ||
+               this.isCodexCommand(commandLine) ||
+               this.isGeminiCommand(commandLine);
+    }
+
     private async activateSidecar(type: AIType, terminal: vscode.Terminal): Promise<void> {
-        const terminalId = this.getTerminalId(terminal);
+        // 터미널 ID 등록 (처음 보는 터미널이면 새 ID 할당)
+        const terminalId = this.registerTerminalId(terminal);
         const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
 
+        // 이미 이 터미널에 세션이 있으면 무시
+        if (this.sessions.has(terminalId)) {
+            return;
+        }
+
+        // ===== 세션별 독립 리소스 생성 =====
+        const snapshotRepository = new InMemorySnapshotRepository();
+        const stateManager = new PanelStateManager();
+
+        // 세션별 UseCase 인스턴스 생성
+        const captureSnapshotsUseCase = new CaptureSnapshotsUseCase(
+            snapshotRepository,
+            this.fileSystemGateway,
+            this.fileGlobber
+        );
+
+        const generateDiffUseCase = new GenerateDiffUseCase(
+            snapshotRepository,
+            this.fileSystemGateway,
+            this.gitPort,
+            this.diffService
+        );
+
+        const addCommentUseCase = new AddCommentUseCase(
+            this.commentRepository
+        );
+
+        // 스냅샷 캡처
         try {
             const config = vscode.workspace.getConfiguration('sidecar');
             const includePatterns = config.get<string[]>('includeFiles', []);
-            await this.captureSnapshotsUseCase.execute(includePatterns);
+            await captureSnapshotsUseCase.execute(includePatterns);
         } catch (error) {
             console.error('Failed to capture snapshots:', error);
         }
 
-        if (workspaceRoot && this.panelStateManager) {
-            await this.captureBaseline(workspaceRoot);
+        // Baseline 캡처
+        if (workspaceRoot) {
+            await this.captureBaseline(workspaceRoot, stateManager);
         }
 
-        await this.moveTerminalToSide();
+        await this.moveTerminalToSide(terminalId);
 
-        await vscode.commands.executeCommand('sidecar.showPanel');
+        // ===== 패널 생성 =====
+        const panel = SidecarPanelAdapter.createNew(this.getExtensionContext(), terminalId);
 
+        // State manager → Panel 연결
+        stateManager.setRenderCallback((state) => panel.render(state));
+
+        // Panel에 UseCase 연결
+        panel.setUseCases(
+            generateDiffUseCase,
+            addCommentUseCase,
+            async () => {
+                const context = this.sessions.get(terminalId);
+                if (context) {
+                    const result = await this.submitCommentsUseCase.execute(context.session);
+                    if (result) {
+                        stateManager.markCommentsAsSubmitted(result.submittedIds);
+                    }
+                }
+            },
+            stateManager,
+            this.symbolPort
+        );
+
+        // ===== SessionContext 생성 및 저장 =====
         const session = AISession.create(type, terminalId);
-        this.activeAISessions.set(terminalId, session);
+        const context: SessionContext = {
+            terminalId,
+            session,
+            snapshotRepository,
+            stateManager,
+            generateDiffUseCase,
+            addCommentUseCase,
+            captureSnapshotsUseCase,
+            disposePanel: () => panel.dispose(),
+        };
+
+        this.sessions.set(terminalId, context);
+
+        // Panel dispose 시 세션 정리
+        panel.onDispose(() => this.flushSession(terminalId));
+
+        // 터미널 등록
         this.terminalGateway.registerTerminal(terminalId, terminal);
 
+        // AI 상태 업데이트
+        stateManager.setAIStatus({ active: true, type });
+
+        // 알림
         vscode.window.showInformationMessage(
             `${session.displayName} detected! Sidecar is now active.`,
             'Show Panel'
         ).then(action => {
             if (action === 'Show Panel') {
-                vscode.commands.executeCommand('sidecar.focusPanel');
+                panel.show();
             }
         });
-
-        if (this.panelStateManager) {
-            this.panelStateManager.setAIStatus({ active: true, type });
-        }
     }
 
+    /**
+     * 세션 플러시 - 모든 관련 리소스 정리
+     */
+    private flushSession(terminalId: string): void {
+        const context = this.sessions.get(terminalId);
+        if (!context) return;
+
+        console.log(`Flushing session: ${context.session.type} (${terminalId})`);
+
+        // 리소스 정리
+        context.snapshotRepository.clear();
+        context.stateManager.reset();
+        (context.stateManager as PanelStateManager).clearRenderCallback();
+
+        // 터미널 등록 해제
+        this.terminalGateway.unregisterTerminal(terminalId);
+
+        // 세션 제거
+        this.sessions.delete(terminalId);
+
+        console.log('Session flushed, panel closed');
+    }
+
+    /** 터미널 → ID 매핑 (터미널 객체 기반) */
+    private terminalIdMap = new WeakMap<vscode.Terminal, string>();
+    private terminalCounter = 0;
+
+    /**
+     * 터미널 고유 ID 조회 (동기)
+     * 이미 등록된 터미널이면 저장된 ID 반환, 아니면 undefined
+     */
     private getTerminalId(terminal: vscode.Terminal): string {
-        return `terminal-${terminal.processId || Date.now()}`;
+        const cached = this.terminalIdMap.get(terminal);
+        if (cached) {
+            return cached;
+        }
+        // 등록되지 않은 터미널 - 새 ID 생성하지 않고 임시 ID 반환
+        // (handleCommandEnd/handleTerminalClose에서 세션을 찾지 못하게 됨)
+        return `terminal-unregistered-${terminal.name || 'unknown'}`;
     }
 
-    private async moveTerminalToSide(): Promise<void> {
-        // Skip if panel is already open to avoid terminal showing on every Claude command
-        if (SidecarPanelAdapter.currentPanel) {
+    /**
+     * 터미널 ID 등록 (새 세션 시작 시 호출)
+     */
+    private registerTerminalId(terminal: vscode.Terminal): string {
+        let id = this.terminalIdMap.get(terminal);
+        if (!id) {
+            const name = terminal.name || 'unnamed';
+            id = `terminal-${name}-${++this.terminalCounter}`;
+            this.terminalIdMap.set(terminal, id);
+        }
+        return id;
+    }
+
+    private async moveTerminalToSide(terminalId: string): Promise<void> {
+        // 이미 이 터미널에 패널이 있으면 스킵
+        if (SidecarPanelAdapter.getPanel(terminalId)) {
             return;
         }
 
         try {
             await vscode.commands.executeCommand('workbench.action.terminal.moveIntoEditor');
         } catch {
-            console.log('Terminal move command not available, continuing with default layout');
+            console.log('Terminal move command not available');
         }
     }
 
-    private async captureBaseline(workspaceRoot: string): Promise<void> {
+    private async captureBaseline(
+        workspaceRoot: string,
+        stateManager: IPanelStateManager
+    ): Promise<void> {
         try {
             const config = vscode.workspace.getConfiguration('sidecar');
             const includePatterns = config.get<string[]>('includeFiles', []);
@@ -178,7 +313,7 @@ export class AIDetectionController {
                 status: statusMap.get(filePath) || 'modified',
             }));
 
-            this.panelStateManager!.setBaseline(baselineFiles);
+            stateManager.setBaseline(baselineFiles);
 
             console.log(`Baseline captured: ${baselineFiles.length} files`);
         } catch (error) {
@@ -188,51 +323,49 @@ export class AIDetectionController {
 
     private handleCommandEnd(event: vscode.TerminalShellExecutionEndEvent): void {
         const terminalId = this.getTerminalId(event.terminal);
-        const session = this.activeAISessions.get(terminalId);
+        const context = this.sessions.get(terminalId);
 
-        if (session) {
-            console.log(`AI session ended: ${session.type}`);
+        if (!context) return;
+
+        const commandLine = event.execution.commandLine.value;
+
+        // AI 명령 종료 시에만 세션 플러시
+        if (this.isAICommand(commandLine)) {
+            console.log(`AI command ended: ${context.session.type} (${terminalId})`);
+            context.disposePanel();  // Panel dispose → flushSession 트리거
         }
     }
 
     private handleTerminalClose(terminal: vscode.Terminal): void {
         const terminalId = this.getTerminalId(terminal);
-        const session = this.activeAISessions.get(terminalId);
+        const context = this.sessions.get(terminalId);
 
-        if (session) {
-            console.log(`AI terminal closed: ${session.type}`);
-            this.activeAISessions.delete(terminalId);
-            this.terminalGateway.unregisterTerminal(terminalId);
-
-            if (this.activeAISessions.size === 0) {
-                this.snapshotRepository.clear();
-
-                if (this.panelStateManager) {
-                    this.panelStateManager.reset();
-                }
-
-                if (SidecarPanelAdapter.currentPanel) {
-                    SidecarPanelAdapter.currentPanel.dispose();
-                }
-
-                console.log('AI session ended, panel closed');
-            }
+        if (context) {
+            console.log(`Terminal closed: ${context.session.type} (${terminalId})`);
+            context.disposePanel();
         }
     }
 
     getActiveSession(terminal?: vscode.Terminal): AISession | undefined {
         if (terminal) {
             const terminalId = this.getTerminalId(terminal);
-            return this.activeAISessions.get(terminalId);
+            return this.sessions.get(terminalId)?.session;
         }
 
         const activeTerminal = vscode.window.activeTerminal;
         if (activeTerminal) {
             const terminalId = this.getTerminalId(activeTerminal);
-            return this.activeAISessions.get(terminalId);
+            return this.sessions.get(terminalId)?.session;
         }
 
-        const sessions = Array.from(this.activeAISessions.values());
-        return sessions[sessions.length - 1];
+        const contexts = Array.from(this.sessions.values());
+        return contexts[contexts.length - 1]?.session;
+    }
+
+    /**
+     * 활성 세션들 반환 (FileWatchController에서 사용)
+     */
+    getSessions(): Map<string, SessionContext> {
+        return this.sessions;
     }
 }

--- a/src/application/ports/outbound/SessionContext.ts
+++ b/src/application/ports/outbound/SessionContext.ts
@@ -1,0 +1,36 @@
+import { AISession } from '../../../domain/entities/AISession';
+import { ISnapshotRepository } from './ISnapshotRepository';
+import { IPanelStateManager } from '../../services/IPanelStateManager';
+import { IGenerateDiffUseCase } from '../inbound/IGenerateDiffUseCase';
+import { IAddCommentUseCase } from '../inbound/IAddCommentUseCase';
+import { ICaptureSnapshotsUseCase } from '../inbound/ICaptureSnapshotsUseCase';
+
+/**
+ * 터미널 하나에 바인딩된 독립 세션 컨텍스트
+ * 패널, 상태, 스냅샷이 모두 이 세션에 격리됨
+ */
+export interface SessionContext {
+    /** 터미널 식별자 */
+    terminalId: string;
+
+    /** AI 세션 정보 */
+    session: AISession;
+
+    /** 이 세션의 스냅샷 저장소 */
+    snapshotRepository: ISnapshotRepository;
+
+    /** 이 세션의 상태 관리자 */
+    stateManager: IPanelStateManager;
+
+    /** 이 세션의 Diff UseCase */
+    generateDiffUseCase: IGenerateDiffUseCase;
+
+    /** 이 세션의 Comment UseCase */
+    addCommentUseCase: IAddCommentUseCase;
+
+    /** 이 세션의 Snapshot UseCase */
+    captureSnapshotsUseCase: ICaptureSnapshotsUseCase;
+
+    /** 패널 dispose 콜백 (AIDetectionController에서 설정) */
+    disposePanel: () => void;
+}

--- a/src/application/ports/outbound/index.ts
+++ b/src/application/ports/outbound/index.ts
@@ -6,3 +6,4 @@ export { IGitPort } from './IGitPort';
 export { INotificationPort } from './INotificationPort';
 export { IFileGlobber } from './IFileGlobber';
 export { ISymbolPort, ScopeInfo } from './ISymbolPort';
+export { SessionContext } from './SessionContext';


### PR DESCRIPTION
- Add SessionContext type for terminal-isolated sessions
- Refactor SidecarPanelAdapter to support multiple panels per terminal
- Refactor AIDetectionController for per-session resource management
- Auto-flush session when AI command ends or terminal closes
- Refactor FileWatchController to propagate changes to all active sessions
- Fix terminal.processId Promise issue (was showing [object Promise])
- Fix markdown inline code placeholder being corrupted by italic formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)